### PR TITLE
feat: Update to Satisfactory 1.2

### DIFF
--- a/FicsitChat.uplugin
+++ b/FicsitChat.uplugin
@@ -1,9 +1,10 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.1.0",
-	"SemVersion": "1.1.0",
+	"VersionName": "1.2.0",
+	"SemVersion": "1.2.0",
 	"AcceptsAnyRemoteVersion": true,
+	"GameVersion": ">=491125",
 	"FriendlyName": "FICSIT.chat",
 	"Description": "Satisfactory to Discord chat bridge.",
 	"Category": "Modding",
@@ -26,7 +27,7 @@
 	"Plugins": [
 		{
 			"Name": "SML",
-			"SemVersion": "^3.7.0",
+			"SemVersion": "^3.12.0",
 			"Enabled": true
 		}
 	]

--- a/Source/FicsitChat/Private/FicsitChatModule.cpp
+++ b/Source/FicsitChat/Private/FicsitChatModule.cpp
@@ -25,21 +25,22 @@ void FFicsitChatModule::ShutdownModule() {
 
 void FFicsitChatModule::RegisterHooks() {
 #if !WITH_EDITOR
-	AFGChatManager *afgChatManager = GetMutableDefault<AFGChatManager>();
-	SUBSCRIBE_METHOD_VIRTUAL_AFTER(AFGChatManager::AddChatMessageToReceived, afgChatManager, [](AFGChatManager *self, FChatMessageStruct newMessage) {
+	SUBSCRIBE_METHOD_AFTER(AFGChatManager::AddChatMessageToReceived, [](AFGChatManager *self, const FChatMessageStruct &newMessage) {
 		UE_LOG(LogFicsitChat, Verbose, TEXT("Chat message by %s sent to all clients: %s"), *newMessage.MessageSender.ToString(), *newMessage.MessageText.ToString());
 
 		FFicsitChat_ConfigStruct config = FFicsitChat_ConfigStruct::GetActiveConfig((UFicsitChatWorldModule *)self->GetWorld());
 		UFicsitChatWorldModule *worldModule = (UFicsitChatWorldModule *)self->GetWorld()->GetSubsystem<UWorldModuleManager>()->FindModule(TEXT("FicsitChat"));
 
+		FString messageText = newMessage.MessageText.ToString().Replace(TEXT("<PlayerName/>"), *newMessage.MessageSender.ToString());
+		if (messageText.EndsWith(TEXT("has joined the game!")) && !config.HasJoinedMessage) {
+			return;
+		}
+		if (messageText.EndsWith(TEXT("has left the game!")) && !config.HasLeftMessage) {
+			return;
+		}
+
 		std::string userName = TCHAR_TO_UTF8(*newMessage.MessageSender.ToString());
-		std::string message = TCHAR_TO_UTF8(*newMessage.MessageText.ToString());
-		if (message == std::string("has joined the game!") && !config.HasJoinedMessage) {
-			return;
-		}
-		if (message == std::string("has left the game!") && !config.HasLeftMessage) {
-			return;
-		}
+		std::string message = TCHAR_TO_UTF8(*messageText);
 
 		dpp::embed embed =
 			dpp::embed().set_color(dpp::colors::orange).set_title(userName).set_description(message).set_footer(dpp::embed_footer().set_text("If you're tired, just remember you can buy a FICSIT™ Coffee Cup at the AWESOME Shop!"));


### PR DESCRIPTION
- Update SML dependency to ^3.12.0 and declare GameVersion >=491125
- Fix the chat hook for AFGChatManager::AddChatMessageToReceived no longer being virtual
- Substitute the new <PlayerName/> token in system messages and fix the join/leave message filters

disclaimer: I used claude to swap the discord bridge for telegram in my fork, and then also tasked it with pulling out the upstreamable bits for 1.2. 